### PR TITLE
Increase max heap for kernel on binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -12,8 +12,11 @@ SCALA_VERSION=2.12.8 ALMOND_VERSION=0.4.0
   sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
   --sources --default=true \
   -o almond
-./almond --install
+./almond --install \
+  --command "java -XX:MaxRAMPercentage=80.0 -jar almond" \
+  --copy-launcher true
 rm -f almond
+
 
 # Install almond for Scala 2.11
 SCALA_VERSION=2.11.12 ALMOND_VERSION=0.4.0
@@ -23,7 +26,9 @@ SCALA_VERSION=2.11.12 ALMOND_VERSION=0.4.0
   sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
   --sources --default=true \
   -o almond-scala-2.11
-./almond-scala-2.11 --install --id scala211 --display-name "Scala (2.11)"
+./almond-scala-2.11 --install --id scala211 --display-name "Scala (2.11)" \
+  --command "java -XX:MaxRAMPercentage=80.0 -jar almond-scala-2.11 --id scala211 --display-name 'Scala (2.11)'" \
+  --copy-launcher true
 rm -f almond-scala-2.11
 
 # Install required Jupyter/JupyterLab extensions


### PR DESCRIPTION
Required to make the TransmogrifAI examples (#6) work on binder, otherwise they run into OOM.

I couldn't find another way to set Java args other than overriding the startup completele via `--command`. Perhaps I missed something, but otherwise I'd suggest we extend the launcher installer to make that easier.