### PR TITLE
Add Scala 2.13/almond 0.8.1 kernel and update notebooks where possible

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -4,23 +4,37 @@
 curl -L -o coursier https://git.io/coursier-cli
 chmod +x coursier
 
-# Install almond for Scala 2.12
-SCALA_VERSION=2.12.8 ALMOND_VERSION=0.5.0
+# Install almond for Scala 2.13
+SCALA_VERSION=2.13.1 ALMOND_VERSION=0.8.2
 ./coursier bootstrap \
   -r jitpack \
   -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
   sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
   --sources --default=true \
-  -o almond
-./almond --install \
-  --command "java -XX:MaxRAMPercentage=80.0 -jar almond" \
+  -o almond-scala-2.13
+./almond-scala-2.13 --install --id scala213 --display-name "Scala (2.13)" \
+  --command "java -XX:MaxRAMPercentage=80.0 -jar almond-scala-2.13 --id scala213 --display-name 'Scala (2.13)'" \
   --copy-launcher \
   --metabrowse
-rm -f almond
+rm -f almond-scala-2.13
 
+# Install almond for Scala 2.12
+SCALA_VERSION=2.12.10 ALMOND_VERSION=0.8.2
+./coursier bootstrap \
+  -r jitpack \
+  -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
+  sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
+  --sources --default=true \
+  -o ./almond-scala-2.12
+./almond-scala-2.12 --install --id scala212 --display-name "Scala (2.12)" \
+  --command "java -XX:MaxRAMPercentage=80.0 -jar almond-scala-2.12 --id scala212 --display-name 'Scala (2.12)'" \
+  --copy-launcher \
+  --metabrowse
+rm -f almond-scala-2.12
 
-# Install almond for Scala 2.11
-SCALA_VERSION=2.11.12 ALMOND_VERSION=0.5.0
+# Install almond 0.6.0 for Scala 2.11
+# TODO remove once TransmogrifAI and vegas are updated for Scala 2.12
+SCALA_VERSION=2.11.12 ALMOND_VERSION=0.6.0
 ./coursier bootstrap \
   -r jitpack \
   -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+nbdime
+jupyterlab-git

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -58,9 +58,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -68,7 +68,7 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   },
   "toc": {
    "base_numbering": 1,
@@ -85,5 +85,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/interactive_computing_article.ipynb
+++ b/notebooks/interactive_computing_article.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import $ivy.`org.typelevel::cats-core:1.5.0`\n",
+    "import $ivy.`org.typelevel::cats-core:2.0.0`\n",
     "import cats.syntax.semigroup._ // for |+|\n",
     "import cats.instances.int._    // for Monoid\n",
     "import cats.instances.option._ // for Monoid\n",
@@ -349,7 +349,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import $ivy.`com.lihaoyi::scalatags:0.6.7`\n",
+    "import $ivy.`com.lihaoyi::scalatags:0.7.0`\n",
     "\n",
     "import jupyter.Displayer, jupyter.Displayers\n",
     "import scala.collection.JavaConverters._\n",
@@ -392,7 +392,7 @@
    "outputs": [],
    "source": [
     "Image\n",
-    "  .from(\"https://scala-lang.org/resources/img/frontpage/scala-spiral.png\")\n",
+    "  .from(\"https://almond.sh/logos/impure-logos-almond-3b.png\")\n",
     "  .withWidth(150)"
    ]
   },
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import $ivy.`org.plotly-scala::plotly-almond:0.7.0`\n",
+    "import $ivy.`org.plotly-scala::plotly-almond:0.7.1`\n",
     "import plotly._, plotly.element._, plotly.layout._, plotly.Almond._\n",
     "{{  \n",
     "  val trace1 = Scatter(\n",
@@ -497,9 +497,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.12)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala212"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -507,9 +507,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.12.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/abstract-types.ipynb
+++ b/notebooks/scala-tour/abstract-types.ipynb
@@ -215,9 +215,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -225,9 +225,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/annotations.ipynb
+++ b/notebooks/scala-tour/annotations.ipynb
@@ -314,9 +314,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -324,9 +324,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/basics.ipynb
+++ b/notebooks/scala-tour/basics.ipynb
@@ -1161,9 +1161,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -1171,9 +1171,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/by-name-parameters.ipynb
+++ b/notebooks/scala-tour/by-name-parameters.ipynb
@@ -115,9 +115,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -125,9 +125,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/case-classes.ipynb
+++ b/notebooks/scala-tour/case-classes.ipynb
@@ -215,9 +215,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -225,9 +225,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/classes.ipynb
+++ b/notebooks/scala-tour/classes.ipynb
@@ -368,9 +368,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -378,9 +378,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/compound-types.ipynb
+++ b/notebooks/scala-tour/compound-types.ipynb
@@ -108,9 +108,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -118,9 +118,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/default-parameter-values.ipynb
+++ b/notebooks/scala-tour/default-parameter-values.ipynb
@@ -153,9 +153,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -163,9 +163,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/extractor-objects.ipynb
+++ b/notebooks/scala-tour/extractor-objects.ipynb
@@ -200,9 +200,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -210,9 +210,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/for-comprehensions.ipynb
+++ b/notebooks/scala-tour/for-comprehensions.ipynb
@@ -205,9 +205,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -215,9 +215,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/generic-classes.ipynb
+++ b/notebooks/scala-tour/generic-classes.ipynb
@@ -117,9 +117,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -127,9 +127,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/higher-order-functions.ipynb
+++ b/notebooks/scala-tour/higher-order-functions.ipynb
@@ -342,9 +342,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -352,9 +352,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/implicit-conversions.ipynb
+++ b/notebooks/scala-tour/implicit-conversions.ipynb
@@ -140,9 +140,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -150,9 +150,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/implicit-parameters.ipynb
+++ b/notebooks/scala-tour/implicit-parameters.ipynb
@@ -119,9 +119,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -129,9 +129,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/inner-classes.ipynb
+++ b/notebooks/scala-tour/inner-classes.ipynb
@@ -214,9 +214,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -224,9 +224,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/lower-type-bounds.ipynb
+++ b/notebooks/scala-tour/lower-type-bounds.ipynb
@@ -181,9 +181,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -191,9 +191,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/mixin-class-composition.ipynb
+++ b/notebooks/scala-tour/mixin-class-composition.ipynb
@@ -244,9 +244,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -254,9 +254,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/multiple-parameter-lists.ipynb
+++ b/notebooks/scala-tour/multiple-parameter-lists.ipynb
@@ -281,9 +281,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -291,9 +291,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/named-arguments.ipynb
+++ b/notebooks/scala-tour/named-arguments.ipynb
@@ -111,9 +111,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -121,9 +121,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/nested-functions.ipynb
+++ b/notebooks/scala-tour/nested-functions.ipynb
@@ -88,9 +88,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -98,9 +98,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/operators.ipynb
+++ b/notebooks/scala-tour/operators.ipynb
@@ -271,9 +271,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -281,9 +281,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/package-objects.ipynb
+++ b/notebooks/scala-tour/package-objects.ipynb
@@ -123,9 +123,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -133,9 +133,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/packages-and-imports.ipynb
+++ b/notebooks/scala-tour/packages-and-imports.ipynb
@@ -189,9 +189,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -199,9 +199,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/pattern-matching.ipynb
+++ b/notebooks/scala-tour/pattern-matching.ipynb
@@ -409,9 +409,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -419,9 +419,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/polymorphic-methods.ipynb
+++ b/notebooks/scala-tour/polymorphic-methods.ipynb
@@ -76,9 +76,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -86,9 +86,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/regular-expression-patterns.ipynb
+++ b/notebooks/scala-tour/regular-expression-patterns.ipynb
@@ -171,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -181,9 +181,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/self-types.ipynb
+++ b/notebooks/scala-tour/self-types.ipynb
@@ -82,9 +82,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -92,9 +92,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/singleton-objects.ipynb
+++ b/notebooks/scala-tour/singleton-objects.ipynb
@@ -244,9 +244,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -254,9 +254,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/tour-of-scala.ipynb
+++ b/notebooks/scala-tour/tour-of-scala.ipynb
@@ -69,9 +69,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -79,9 +79,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/traits.ipynb
+++ b/notebooks/scala-tour/traits.ipynb
@@ -227,9 +227,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -237,9 +237,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/tuples.ipynb
+++ b/notebooks/scala-tour/tuples.ipynb
@@ -273,9 +273,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -283,9 +283,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/type-inference.ipynb
+++ b/notebooks/scala-tour/type-inference.ipynb
@@ -298,9 +298,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -308,9 +308,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/unified-types.ipynb
+++ b/notebooks/scala-tour/unified-types.ipynb
@@ -209,9 +209,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -219,9 +219,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/upper-type-bounds.ipynb
+++ b/notebooks/scala-tour/upper-type-bounds.ipynb
@@ -131,9 +131,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -141,9 +141,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scala-tour/variances.ipynb
+++ b/notebooks/scala-tour/variances.ipynb
@@ -438,9 +438,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -448,9 +448,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/scalameta/tree-guide.ipynb
+++ b/notebooks/scalameta/tree-guide.ipynb
@@ -32,13 +32,13 @@
    "source": [
     "```scala\n",
     "// build.sbt\n",
-    "libraryDependencies += \"org.scalameta\" %% \"scalameta\" % \"4.1.4\"\n",
+    "libraryDependencies += \"org.scalameta\" %% \"scalameta\" % \"4.2.3\"\n",
     "\n",
     "// For Scala.js, Scala Native\n",
-    "libraryDependencies += \"org.scalameta\" %%% \"scalameta\" % \"4.1.4\"\n",
+    "libraryDependencies += \"org.scalameta\" %%% \"scalameta\" % \"4.2.3\"\n",
     "```\n",
     "\n",
-    "[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.12)\n",
+    "[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.13)\n",
     "\n",
     "All code examples assume you have the following import\n",
     "\n",
@@ -84,7 +84,7 @@
    ],
    "source": [
     "// Ammonite REPL\n",
-    "import $ivy.`org.scalameta::scalameta:4.1.4`, scala.meta._"
+    "import $ivy.`org.scalameta::scalameta:4.2.3`, scala.meta._"
    ]
   },
   {
@@ -1610,9 +1610,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -1620,9 +1620,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/spark.ipynb
+++ b/notebooks/spark.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "For more information, see the [README](https://github.com/alexarchambault/ammonite-spark/blob/master/README.md) of ammonite-spark.\n",
     "\n",
-    "To use it, import the *almond-spark* dependency as well as Spark 2.x itself."
+    "To use it, just import Spark 2.x, the *almond-spark* dependency will be added automatically."
    ]
   },
   {
@@ -46,7 +46,7 @@
    ],
    "source": [
     "import $ivy.`org.apache.spark::spark-sql:2.4.3` // Or use any other 2.x version here\n",
-    "import $ivy.`sh.almond::almond-spark:0.6.0`\n",
+    "// import $ivy.`sh.almond::almond-spark:_` // Added automatically on importing Spark\n",
     "\n",
     "import org.apache.spark.sql._"
    ]
@@ -627,9 +627,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.12)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala212"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -637,7 +637,7 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.12.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/tensorflow_scala.ipynb
+++ b/notebooks/tensorflow_scala.ipynb
@@ -610,9 +610,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.12)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala212"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -620,9 +620,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.12.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/visualization/evilplot.ipynb
+++ b/notebooks/visualization/evilplot.ipynb
@@ -127,9 +127,9 @@
    "id": "021a0a089e31e6dbbc66f25ef8a86ce1"
   },
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -137,7 +137,7 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.8"
+   "version": "2.13.1"
   },
   "toc": {
    "base_numbering": 1,
@@ -154,5 +154,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/visualization/plotly_examples.ipynb
+++ b/notebooks/visualization/plotly_examples.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "import $ivy.`org.plotly-scala::plotly-almond:0.7.0`\n",
+    "import $ivy.`org.plotly-scala::plotly-almond:0.7.1`\n",
     "import plotly._, plotly.element._, plotly.layout._, plotly.Almond._\n",
     "\n",
     "// if you want to have the plots available without an internet connection:\n",
@@ -1965,9 +1965,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Scala",
+   "display_name": "Scala (2.13)",
    "language": "scala",
-   "name": "scala"
+   "name": "scala213"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",
@@ -1975,9 +1975,9 @@
    "mimetype": "text/x-scala",
    "name": "scala",
    "nbconvert_exporter": "script",
-   "version": "2.12.7"
+   "version": "2.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Keeps almond 0.6 on Scala 2.11 because we have a few examples we can't upgrade yet.