### PR TITLE
Update to 0.11.1

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -5,7 +5,7 @@ set -e
 curl -fLo cs https://github.com/coursier/coursier/releases/download/v2.0.3/cs-x86_64-pc-linux
 chmod +x cs
 
-ALMOND_VERSION=0.10.9
+ALMOND_VERSION=0.11.0
 
 # Install almond for Scala 2.13
 ./cs launch "almond:$ALMOND_VERSION" --scala 2.13.3 -- \

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -5,7 +5,7 @@ set -e
 curl -fLo cs https://github.com/coursier/coursier/releases/download/v2.0.3/cs-x86_64-pc-linux
 chmod +x cs
 
-ALMOND_VERSION=0.11.0
+ALMOND_VERSION=0.11.1
 
 # Install almond for Scala 2.13
 ./cs launch "almond:$ALMOND_VERSION" --scala 2.13.3 -- \

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,3 @@
 nbdime
 jupyterlab-git
+jupyterlab~=2.0


### PR DESCRIPTION
for the import fix.
plus pin jupyterlab to v2 for compatibilty with almond-scalafmt since mybinder now uses jupyterlab v3 by default.